### PR TITLE
Feat/Design: 공용 컴포넌트 Input/Textarea 1차 수정

### DIFF
--- a/components/@common/Input.tsx
+++ b/components/@common/Input.tsx
@@ -7,7 +7,6 @@ import { cn } from "@/lib/utils";
 const variant = cva(
   [
     "w-full",
-    "cursor-text",
     "rounded-xl border border-solid border-primary hover:border-brand-border focus:border-brand-border",
     "p-4",
     "text-default-light placeholder:text-placeHolder",

--- a/components/@common/Input.tsx
+++ b/components/@common/Input.tsx
@@ -7,8 +7,7 @@ import { cn } from "@/lib/utils";
 const variant = cva(
   [
     "w-full",
-    "rounded-xl border border-solid border-primary hover:border-hover focus:border-focus",
-    "bg-input-default",
+    "rounded-xl border border-solid border-primary hover:border-brand-border focus:border-brand-border",
     "p-4",
     "text-default-light placeholder:text-placeHolder",
   ],
@@ -32,6 +31,10 @@ const variant = cva(
         md: "max-tab:py-3",
         lg: "tab:px-6",
       },
+      bgColor: {
+        default: "bg-input-default",
+        white: "bg-white",
+      },
       error: {
         true: "border-danger",
       },
@@ -48,22 +51,39 @@ const variant = cva(
       boxSize: "default",
       fontSize: "default",
       padding: "default",
+      bgColor: "default",
     },
   },
 );
 
 type Props = InputHTMLAttributes<HTMLInputElement> &
-  VariantProps<typeof variant>;
+  VariantProps<typeof variant> & {
+    errorMessage?: string;
+  };
 
 export default forwardRef<HTMLInputElement, Props>(function Input(
-  { boxSize, fontSize, padding, error, className, ...props },
+  {
+    boxSize,
+    fontSize,
+    padding,
+    bgColor,
+    error,
+    errorMessage,
+    className,
+    ...props
+  },
   ref,
 ) {
   return (
-    <input
-      className={cn(variant({ boxSize, fontSize, padding, error, className }))}
-      ref={ref}
-      {...props}
-    />
+    <section className="flex w-full flex-col gap-y-2">
+      <input
+        className={cn(
+          variant({ boxSize, fontSize, padding, bgColor, error, className }),
+        )}
+        ref={ref}
+        {...props}
+      />
+      {errorMessage && <p className="md-medium text-danger">{errorMessage}</p>}
+    </section>
   );
 });

--- a/components/@common/Input.tsx
+++ b/components/@common/Input.tsx
@@ -13,62 +13,62 @@ const variant = cva(
   ],
   {
     variants: {
-      boxSize: {
+      BoxSize: {
         default: "h-11 tab:h-12",
         sm: "h-11",
         md: "h-12",
         lg: "h-12 tab:h-14",
       },
-      fontSize: {
+      FontSize: {
         default: "md-normal tab:lg-normal",
         sm: "md-normal",
         lg: "lg-normal",
       },
-      padding: {
+      Padding: {
         default: "py-[10px] tab:py-3",
         xs: "py-[6px] tab:py-2",
         sm: "px-3 py-[10px]",
         md: "max-tab:py-3",
         lg: "tab:px-6",
       },
-      bgColor: {
+      BgColor: {
         default: "bg-input-default",
         white: "bg-white",
       },
-      error: {
+      Error: {
         true: "border-danger",
       },
     },
     compoundVariants: [
       {
-        boxSize: "sm",
-        fontSize: "sm",
-        padding: "sm",
+        BoxSize: "sm",
+        FontSize: "sm",
+        Padding: "sm",
         className: "font-medium",
       },
     ],
     defaultVariants: {
-      boxSize: "default",
-      fontSize: "default",
-      padding: "default",
-      bgColor: "default",
+      BoxSize: "default",
+      FontSize: "default",
+      Padding: "default",
+      BgColor: "default",
     },
   },
 );
 
 type Props = InputHTMLAttributes<HTMLInputElement> &
   VariantProps<typeof variant> & {
-    errorMessage?: string;
+    ErrorMessage?: string;
   };
 
 export default forwardRef<HTMLInputElement, Props>(function Input(
   {
-    boxSize,
-    fontSize,
-    padding,
-    bgColor,
-    error,
-    errorMessage,
+    BoxSize,
+    FontSize,
+    Padding,
+    BgColor,
+    Error,
+    ErrorMessage,
     className,
     ...props
   },
@@ -78,12 +78,12 @@ export default forwardRef<HTMLInputElement, Props>(function Input(
     <section className="flex w-full flex-col gap-y-2">
       <input
         className={cn(
-          variant({ boxSize, fontSize, padding, bgColor, error, className }),
+          variant({ BoxSize, FontSize, Padding, BgColor, Error, className }),
         )}
         ref={ref}
         {...props}
       />
-      {errorMessage && <p className="md-medium text-danger">{errorMessage}</p>}
+      {ErrorMessage && <p className="md-medium text-danger">{ErrorMessage}</p>}
     </section>
   );
 });

--- a/components/@common/Input.tsx
+++ b/components/@common/Input.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 const variant = cva(
   [
     "w-full",
+    "cursor-text",
     "rounded-xl border border-solid border-primary hover:border-brand-border focus:border-brand-border",
     "p-4",
     "text-default-light placeholder:text-placeHolder",

--- a/components/@common/Textarea.tsx
+++ b/components/@common/Textarea.tsx
@@ -7,7 +7,6 @@ import { cn } from "@/lib/utils";
 const variant = cva(
   [
     "w-full",
-    "cursor-text",
     "rounded-xl border border-solid border-primary",
     "bg-input-default",
     "text-default-light placeholder:text-placeHolder",

--- a/components/@common/Textarea.tsx
+++ b/components/@common/Textarea.tsx
@@ -13,34 +13,34 @@ const variant = cva(
   ],
   {
     variants: {
-      boxSize: {
+      BoxSize: {
         default: "h-[75px]",
         sm: "h-[50px]",
         md: "h-[6.5rem]",
         lg: "h-60",
       },
-      fontSize: {
+      FontSize: {
         default: "md-normal tab:lg-normal",
         sm: "md-normal",
         lg: "lg-normal",
       },
-      padding: {
+      Padding: {
         default: "px-4 py-3",
         lg: "p-4 max-tab:py-2 tab:px-6",
       },
     },
     compoundVariants: [
       {
-        boxSize: ["md", "lg"],
-        fontSize: "default",
-        padding: "lg",
+        BoxSize: ["md", "lg"],
+        FontSize: "default",
+        Padding: "lg",
         className: "!leading-[26px]",
       },
     ],
     defaultVariants: {
-      boxSize: "default",
-      fontSize: "default",
-      padding: "default",
+      BoxSize: "default",
+      FontSize: "default",
+      Padding: "default",
     },
   },
 );
@@ -49,12 +49,12 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> &
   VariantProps<typeof variant>;
 
 export default forwardRef<HTMLTextAreaElement, Props>(function Textarea(
-  { boxSize, fontSize, padding, className, ...props },
+  { BoxSize, FontSize, Padding, className, ...props },
   ref,
 ) {
   return (
     <textarea
-      className={cn(variant({ boxSize, fontSize, padding, className }))}
+      className={cn(variant({ BoxSize, FontSize, Padding, className }))}
       ref={ref}
       {...props}
     />

--- a/components/@common/Textarea.tsx
+++ b/components/@common/Textarea.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 const variant = cva(
   [
     "w-full",
+    "cursor-text",
     "rounded-xl border border-solid border-primary",
     "bg-input-default",
     "text-default-light placeholder:text-placeHolder",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,6 +35,24 @@ select {
   cursor: pointer;
 }
 
+textarea,
+input {
+  cursor: text;
+}
+
+input[type="checkbox"],
+input[type="color"],
+input[type="date"],
+input[type="datetime-local"],
+input[type="image"],
+input[type="month"],
+input[type="range"],
+input[type="reset"],
+input[type="time"],
+input[type="week"] {
+  cursor: pointer;
+}
+
 /* input type number 에서 화살표 제거 */
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {


### PR DESCRIPTION
## 작업 내용

- error 상태 관련 코드 추가
- BgColor를 선택할 수 있게 변경
- hover, focus 상태 시 borderColor 변경
  - 기존 컴포넌트에서 tailwind css로 변경했던거 취소
  - globals.css에서 변경
- cn 관련 Prop 앞글자 대문자로 변경
  - 인텔리센스 사용시  cn 관련 Prop이 먼저 나옴

## 리뷰 요구사항

- 

## 기타

- 
