### PR TITLE
Fix: layout revalidate 적용 & Content-Type 문제 해결

### DIFF
--- a/apis/fetchExtended.ts
+++ b/apis/fetchExtended.ts
@@ -68,4 +68,48 @@ const fetchExtended = returnFetch({
   },
 });
 
+export const fetchExtendedForm = returnFetch({
+  baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+  headers: {
+    credentials: "include",
+  },
+  interceptors: {
+    request: async (args: FetchArgs) => {
+      if (args[0] instanceof URL) {
+        const url = args[0];
+        const { pathname } = url;
+        url.pathname = `/8-7${pathname}`;
+      }
+
+      if (!args[1]?.headers) return args;
+
+      let accessToken;
+      if (typeof window === "undefined")
+        accessToken = await getServerCookie("accessToken");
+      else accessToken = getCookie("accessToken");
+
+      if (!accessToken) return args;
+
+      const timeRemaining =
+        jwtDecode(accessToken).exp! - Math.floor(new Date().getTime() / 1000);
+
+      if (timeRemaining <= 0) {
+        accessToken = await refreshAccessToken();
+      }
+
+      const { headers } = args[1];
+      const headerInit: HeadersInit = new Headers(headers);
+      headerInit.set("Authorization", `Bearer ${accessToken}`);
+      const newArgs: FetchArgs = [
+        args[0],
+        {
+          ...args[1],
+          headers: headerInit,
+        },
+      ];
+      return newArgs;
+    },
+  },
+});
+
 export default fetchExtended;

--- a/apis/image.ts
+++ b/apis/image.ts
@@ -1,12 +1,7 @@
-import { getSession } from "next-auth/react";
-
 import { ImageUploadResponse } from "@/dtos/ImageDtos";
 
-import { auth } from "@/auth";
+import { fetchExtendedForm } from "./fetchExtended";
 
-// fetchExtended에 기본적으로 application/json으로 content-type이 정해져 있어서
-// formdata를 사용하는 경우 multipart/form-data로 정하더라도 boundary 값이 할당되지 않아서 에러가 발생 (status: 500)
-// 그래서 fetchExtended를 사용하지 않고 코드 작성 -> 이후에 fetchExtended가 수정된다면 사용 가능
 export async function uploadImage(
   imageFile: File,
 ): Promise<ImageUploadResponse> {
@@ -19,22 +14,11 @@ export async function uploadImage(
   const formData = new FormData();
   formData.append("image", imageFile);
 
-  let session;
-  if (typeof window !== "undefined") {
-    session = await getSession();
-  } else {
-    session = await auth();
-  }
-  const accessToken = session?.accessToken;
-
-  const res = await fetch(
+  const res = await fetchExtendedForm(
     `${process.env.NEXT_PUBLIC_BASE_URL}/8-7/images/upload`,
     {
       method: "POST",
       body: formData,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
     },
   );
   const json = await res.json();

--- a/apis/image.ts
+++ b/apis/image.ts
@@ -14,13 +14,10 @@ export async function uploadImage(
   const formData = new FormData();
   formData.append("image", imageFile);
 
-  const res = await fetchExtendedForm(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/8-7/images/upload`,
-    {
-      method: "POST",
-      body: formData,
-    },
-  );
+  const res = await fetchExtendedForm(`/images/upload`, {
+    method: "POST",
+    body: formData,
+  });
   const json = await res.json();
 
   if (!res.ok) {

--- a/app/(pages)/(team)/jointeam/page.tsx
+++ b/app/(pages)/(team)/jointeam/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/@common/Button";
 import Input from "@/components/@common/Input";
 import Container from "@/components/@common/container/Container";
 import { useToast } from "@/hooks/useToast";
+import { revalidateLayout } from "@/lib/revalidate";
 import { useAcceptInvitation } from "@/queries/group";
 
 export default function JoinTeamPage() {
@@ -51,6 +52,7 @@ export default function JoinTeamPage() {
         (() => toast({ title: "팀 참여에 성공했습니다!" }))();
 
         const { groupId: teamId } = response;
+        revalidateLayout();
         router.push(`/${teamId}`);
       },
     });

--- a/app/(pages)/[teamid]/page.tsx
+++ b/app/(pages)/[teamid]/page.tsx
@@ -1,3 +1,0 @@
-export default function page() {
-  return <div />;
-}

--- a/components/layout/HeaderLayout.tsx
+++ b/components/layout/HeaderLayout.tsx
@@ -8,7 +8,7 @@ export default async function HeaderLayout() {
   const accessToken = cookieStore.get("accessToken");
 
   return (
-    <header className="sticky w-full bg-brand-header">
+    <header className="fixed w-full bg-brand-header">
       <div className="lg-medium relative mx-auto flex h-[60px] max-w-[1440px] items-center px-4 tab:px-6">
         {accessToken ? <AuthHeader /> : <UnAuthHeader />}
       </div>

--- a/components/layout/groups/GroupsResponsive.tsx
+++ b/components/layout/groups/GroupsResponsive.tsx
@@ -3,21 +3,24 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 
+import { getUserGroups } from "@/apis/user";
 import NavigationMenuGroups from "@/layout/groups/NavigationMenuGroups";
 import SheetGroups from "@/layout/groups/SheetGroups";
 import Logo from "@/public/images/logo.png";
 
-export default function GroupsResponsive() {
+export default async function GroupsResponsive() {
+  const groups = await getUserGroups();
+
   return (
     <nav className="flex grow items-center gap-4 tab:gap-8 pc:gap-10">
       <div className="tab:hidden">
-        <SheetGroups />
+        <SheetGroups groups={groups} />
       </div>
       <Link href="/">
         <Image width={65} height={32} src={Logo} alt="로고" />
       </Link>
       <div className="lg-medium hidden items-center gap-4 tab:flex">
-        <NavigationMenuGroups />
+        <NavigationMenuGroups groups={groups} />
         <Link className="p-2 hover:bg-primary-light" href="/boards">
           자유게시판
         </Link>

--- a/components/layout/groups/NavigationMenuGroups.tsx
+++ b/components/layout/groups/NavigationMenuGroups.tsx
@@ -15,12 +15,14 @@ import {
   navigationMenuTriggerStyle,
   NavigationMenuViewport,
 } from "@/components/@common/modal/NavigationMenu";
+import { UserGroupsResponse } from "@/dtos/UserDtos";
 import { cn } from "@/lib/utils";
-import { useUserGroups } from "@/queries/user";
 
-// Navigation Menu의 외곽선이 지워지지 않음 (border-0, shadow-none을 적용했을 때 무반응)
-export default function NavigationMenuGroups() {
-  const { data: groups } = useUserGroups();
+export default function NavigationMenuGroups({
+  groups,
+}: {
+  groups: UserGroupsResponse[];
+}) {
   const { teamid: teamId } = useParams();
 
   const foundGroupName =

--- a/components/layout/groups/SheetGroups.tsx
+++ b/components/layout/groups/SheetGroups.tsx
@@ -7,9 +7,9 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 
 import { Button } from "@/components/@common/Button";
+import { UserGroupsResponse } from "@/dtos/UserDtos";
 import { cn } from "@/lib/utils";
 import Burger from "@/public/svg/burger";
-import { useUserGroups } from "@/queries/user";
 import { navigationMenuTriggerStyle } from "@/ui/navigation-menu";
 import {
   Sheet,
@@ -19,8 +19,11 @@ import {
   SheetTrigger,
 } from "@/ui/sheet";
 
-export default function SheetGroups() {
-  const { data: groups } = useUserGroups();
+export default function SheetGroups({
+  groups,
+}: {
+  groups: UserGroupsResponse[];
+}) {
   const { teamid: teamId } = useParams();
   const [open, setOpen] = useState(false);
 

--- a/components/team/add_team/AddTeamForm.tsx
+++ b/components/team/add_team/AddTeamForm.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/@common/Button";
 import { useToast } from "@/hooks/useToast";
+import { revalidateLayout } from "@/lib/revalidate";
 import { useAddTeam } from "@/queries/group";
 
 import TeamImageInput from "./TeamImageInput";
@@ -96,6 +97,7 @@ export default function AddTeamForm() {
           (() => toast({ title: "팀 생성에 성공했습니다!" }))();
 
           const { id: teamId } = response;
+          revalidateLayout();
           router.push(`/${teamId}`);
         },
       },

--- a/lib/revalidate.ts
+++ b/lib/revalidate.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateLayout() {
+  revalidatePath(`/`, "layout");
+}


### PR DESCRIPTION
## 작업 내용

### layout revalidate 적용
![image](https://github.com/user-attachments/assets/8f467c4d-11d7-41d3-9b1a-f9b423de046d)

- layout에서 팀 목록과 유저 프로필 데이터를 사용하고 있다.
- layout 컴포넌트는 한번의 렌더링 후 페이지를 이동해도 그대로 사용하게 된다.
- 그래서 revalidate를 하여 새로운 데이터를 불러올 수 있게 만들었다.
- revalidatePath는 서버에서 불러온 데이터만 최신화하므로 useQuery를 사용하지 않도록 헤더를 수정함

### Content-Type 문제 해결
![image](https://github.com/user-attachments/assets/758fb9a6-c877-49fb-8055-5b5e3ff19e13)

- 위 코드의 fetchExtendedForm은 Content-Type이 적용되지 않은 fetch 함수다.
- Content-Type을 작성하지 않았기 때문에, 클라이언트에서 boundary를 알아서 만들어 요청을 하게 된다.

## 기타

- Closes #72 
- Closes #63 
