### PR TITLE
Feat: 팀 타이틀 기능 구현

### DIFF
--- a/apis/group.ts
+++ b/apis/group.ts
@@ -2,6 +2,7 @@ import {
   AcceptInvitationResponse,
   GetTeamResponse,
   AddTeamResponse,
+  EditTeamResponse,
   GetTeamMemberResponse,
 } from "@/dtos/GroupDtos";
 
@@ -52,6 +53,37 @@ export async function addTeam({
 
   const res = await fetchExtended("/groups", {
     method: "POST",
+    body: JSON.stringify({ image: imageUrl, name }),
+  });
+  const json = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message);
+  }
+
+  return json;
+}
+
+export async function editTeam({
+  groupId,
+  image,
+  name,
+}: {
+  groupId: number;
+  image: File | string;
+  name: string;
+}): Promise<EditTeamResponse> {
+  // image를 string으로 받는 경우 기존 이미지를 그대로 사용한다고 생각하고 작성함
+  let imageUrl;
+  if (typeof image === "string") {
+    imageUrl = image;
+  } else {
+    const { url } = await uploadImage(image);
+    imageUrl = url;
+  }
+
+  const res = await fetchExtended(`/groups/${groupId}`, {
+    method: "PATCH",
     body: JSON.stringify({ image: imageUrl, name }),
   });
   const json = await res.json();

--- a/apis/group.ts
+++ b/apis/group.ts
@@ -1,5 +1,6 @@
 import {
   AcceptInvitationResponse,
+  GetTeamResponse,
   AddTeamResponse,
   GetTeamMemberResponse,
 } from "@/dtos/GroupDtos";
@@ -27,6 +28,16 @@ export async function acceptInvitation(
     throw new Error(json.message);
   }
 
+  return json;
+}
+
+export async function getTeam({
+  groupId,
+}: {
+  groupId: number;
+}): Promise<GetTeamResponse> {
+  const res = await fetchExtended(`/groups/${groupId}`);
+  const json = await res.json();
   return json;
 }
 

--- a/apis/group.ts
+++ b/apis/group.ts
@@ -95,6 +95,22 @@ export async function editTeam({
   return json;
 }
 
+export async function delTeam({ groupId }: { groupId: number }) {
+  const res = await fetchExtended(`/groups/${groupId}`, {
+    method: "DELETE",
+  });
+
+  if (res.status === 204) {
+    return;
+  }
+
+  const json = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message);
+  }
+}
+
 export async function getTeamMember({
   groupId,
   memberUserId,

--- a/components/team/with_team/TeamTitle.tsx
+++ b/components/team/with_team/TeamTitle.tsx
@@ -1,4 +1,20 @@
+"use client";
+
+import { ChangeEvent, MouseEvent, useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/@common/Button";
+import Input from "@/@common/Input";
+import ActionsDropDown from "@/@common/dropdown/ActionsDropDown";
+import Modal from "@/@common/modal/Modal";
+import { useToast } from "@/hooks/useToast";
+import useToggle from "@/hooks/useToggle";
+import { revalidateLayout } from "@/lib/revalidate";
 import Sawtooth from "@/public/svg/sawtooth.svg";
+import Warning from "@/public/svg/warning.svg";
+import { useDelTeam, useEditTeam, useGetTeam } from "@/queries/group";
 
 interface TeamTitleProps {
   isAdmin: boolean;
@@ -6,10 +22,141 @@ interface TeamTitleProps {
 }
 
 export default function TeamTitle({ isAdmin, groupId }: TeamTitleProps) {
+  const queryClient = useQueryClient();
+
+  const [isEditModalOpen, toggleIsEditModalOpen] = useToggle(false);
+  const [isDelModalOpen, toggleIsDelModalOpen] = useToggle(false);
+
+  // string | undefined로 추론되기 때문에 우선은 as string으로 처리하였으나 useGetTeam에서 에러 처리를 하게 되면 필요 없어짐
+  const { data: teamData } = useGetTeam(groupId);
+  const imageUrl = teamData?.image as string;
+  const currentTeamName = teamData?.name as string;
+
+  const [teamNameInputValue, setTeamNameInputValue] = useState(currentTeamName);
+  const [teamNameInputErrorMessage, setTeamNameInputErrorMessage] =
+    useState("");
+
+  const { mutate: editTeam } = useEditTeam();
+  const { mutate: delTeam } = useDelTeam();
+
+  const { toast } = useToast();
+  const router = useRouter();
+
+  // 팀수정하기 모달의 input change 핸들러
+  const handleTeamNameInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTeamNameInputValue(e.target.value);
+
+    if (teamNameInputErrorMessage) {
+      setTeamNameInputErrorMessage("");
+    }
+  };
+
+  // 팀수정하기 모달의 수정하기 button click 핸들러
+  // 1. 팀 이름이 이전과 동일하면 api 요청 x + error message
+  // 2. 이외에는 수정하기 요청을 보내고 error message를 띄움 성공시에는 팀 페이지의 이름 변경을 위해 invalidateQuery
+  const handleTeamEditButtonClick = (e: MouseEvent) => {
+    if (currentTeamName === teamNameInputValue) {
+      e.stopPropagation();
+      setTeamNameInputErrorMessage("팀 이름이 동일합니다.");
+      return;
+    }
+
+    editTeam(
+      { groupId, image: imageUrl, name: teamNameInputValue },
+      {
+        onError: (error) => {
+          e.stopPropagation();
+          setTeamNameInputErrorMessage(error.message);
+        },
+        onSuccess: () =>
+          queryClient.invalidateQueries({ queryKey: ["team", groupId] }),
+      },
+    );
+  };
+
+  // 팀 삭제에 성공시 toast를 띄우고 메인 페이지로 이동시킴
+  const handleTeamDelButtonClick = () => {
+    delTeam(
+      { groupId },
+      {
+        onSuccess: () => {
+          (() => toast({ title: "팀 삭제를 완료했습니다!" }))();
+          revalidateLayout();
+          router.push("/");
+        },
+      },
+    );
+  };
+
   return (
     <div className="xl-bold flex h-[64px] justify-between rounded-xl bg-dropDown-default px-6 py-5 text-default-light">
-      경영관리팀 {groupId}
-      {isAdmin && <Sawtooth />}
+      {currentTeamName}
+      {isAdmin && (
+        <>
+          <ActionsDropDown
+            onEditHandler={toggleIsEditModalOpen}
+            onDeleteHandler={toggleIsDelModalOpen}
+          >
+            <Sawtooth />
+          </ActionsDropDown>
+
+          {/* 팀 수정하기 모달 */}
+          <Modal
+            trigger={isEditModalOpen}
+            type="modal"
+            title="팀 이름"
+            hasCrossCloseIcon
+            onOpenChange={toggleIsEditModalOpen}
+            footer={
+              <Button className="flex-1" onClick={handleTeamEditButtonClick}>
+                수정 하기
+              </Button>
+            }
+          >
+            <Input
+              placeholder="팀 이름을 작성해주세요."
+              onChange={handleTeamNameInputChange}
+              defaultValue={currentTeamName}
+              value={teamNameInputValue}
+              Error={!!teamNameInputErrorMessage}
+              ErrorMessage={teamNameInputErrorMessage}
+            />
+          </Modal>
+
+          {/* 팀 삭제하기 모달 */}
+          <Modal
+            trigger={isDelModalOpen}
+            type="modal"
+            onOpenChange={toggleIsDelModalOpen}
+            footer={
+              <>
+                <Button className="flex-1" variant="outlinedSecondary">
+                  닫기
+                </Button>
+                <Button
+                  className="flex-1"
+                  variant="danger"
+                  onClick={handleTeamDelButtonClick}
+                >
+                  삭제 하기
+                </Button>
+              </>
+            }
+          >
+            <div className="text-center">
+              <Warning width="24" height="24" className="mx-auto mb-4" />
+              <h2 className="lg-medium mb-2 text-default-light">
+                &apos;{currentTeamName}&apos;
+                <br />
+                팀을 정말 삭제하시겠어요?
+              </h2>
+              <p className="md-medium text-default-dark">
+                삭제 후에는 되돌릴 수 없습니다.
+              </p>
+            </div>
+          </Modal>
+        </>
+      )}
     </div>
   );
 }

--- a/dtos/GroupDtos.ts
+++ b/dtos/GroupDtos.ts
@@ -2,6 +2,36 @@ export interface AcceptInvitationResponse {
   groupId: number;
 }
 
+interface Member {
+  role: "ADMIN" | "MEMBER";
+  userImage: string | null;
+  userEmail: string;
+  userName: string;
+  groupId: number;
+  userId: number;
+}
+
+interface Task {
+  displayIndex: number;
+  groupId: number;
+  updatedAt: string;
+  createdAt: string;
+  name: string;
+  id: number;
+  tasks: string[];
+}
+
+export interface GetTeamResponse {
+  teamId: string;
+  updatedAt: string;
+  createdAt: string;
+  image: string;
+  name: string;
+  id: number;
+  members: Member[];
+  taskLists: Task[];
+}
+
 export interface AddTeamResponse {
   name: string;
   image: string;
@@ -10,11 +40,4 @@ export interface AddTeamResponse {
   id: number;
 }
 
-export interface GetTeamMemberResponse {
-  userId: number;
-  groupId: number;
-  userName: string;
-  userEmail: string;
-  userImage: string | null;
-  role: "ADMIN" | "MEMBER";
-}
+export type GetTeamMemberResponse = Member;

--- a/dtos/GroupDtos.ts
+++ b/dtos/GroupDtos.ts
@@ -40,4 +40,8 @@ export interface AddTeamResponse {
   id: number;
 }
 
+export interface EditTeamResponse extends AddTeamResponse {
+  teamId: string;
+}
+
 export type GetTeamMemberResponse = Member;

--- a/public/svg/warning.svg
+++ b/public/svg/warning.svg
@@ -1,0 +1,5 @@
+<svg width="current" height="current" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#EF4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 8V12" stroke="#EF4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 16H12.01" stroke="#EF4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -1,6 +1,12 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 
-import { acceptInvitation, getTeam, addTeam, editTeam } from "@/apis/group";
+import {
+  acceptInvitation,
+  getTeam,
+  addTeam,
+  editTeam,
+  delTeam,
+} from "@/apis/group";
 
 export function useAcceptInvitation() {
   return useMutation({
@@ -33,5 +39,11 @@ export function useEditTeam() {
       image: File | string;
       name: string;
     }) => editTeam({ groupId, image, name }),
+  });
+}
+
+export function useDelTeam() {
+  return useMutation({
+    mutationFn: ({ groupId }: { groupId: number }) => delTeam({ groupId }),
   });
 }

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -1,10 +1,17 @@
-import { useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 
-import { acceptInvitation, addTeam } from "@/apis/group";
+import { acceptInvitation, getTeam, addTeam } from "@/apis/group";
 
 export function useAcceptInvitation() {
   return useMutation({
     mutationFn: (token: string) => acceptInvitation(token),
+  });
+}
+
+export function useGetTeam(groupId: number) {
+  return useQuery({
+    queryKey: ["team", groupId],
+    queryFn: () => getTeam({ groupId }),
   });
 }
 

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 
-import { acceptInvitation, getTeam, addTeam } from "@/apis/group";
+import { acceptInvitation, getTeam, addTeam, editTeam } from "@/apis/group";
 
 export function useAcceptInvitation() {
   return useMutation({
@@ -19,5 +19,19 @@ export function useAddTeam() {
   return useMutation({
     mutationFn: ({ image, name }: { image: File; name: string }) =>
       addTeam({ image, name }),
+  });
+}
+
+export function useEditTeam() {
+  return useMutation({
+    mutationFn: ({
+      groupId,
+      image,
+      name,
+    }: {
+      groupId: number;
+      image: File | string;
+      name: string;
+    }) => editTeam({ groupId, image, name }),
   });
 }


### PR DESCRIPTION
## 작업 내용

- 팀 타이틀의 기능을 구현하였습니다.
- 해당 팀 페이지의 관리자인 경우에 팀 타이틀에 톱니바퀴 모양의 드롭다운 트리거가 표시됩니다.
![image](https://github.com/user-attachments/assets/1ea41c9c-77d0-47a9-b3df-2a01ac52b7ab)
- 팀 수정하기를 클릭 시 팀 수정하기 모달이 열립니다. (이미지 변경은 X)
![image](https://github.com/user-attachments/assets/388f9968-69c8-4cee-ad35-f383846de5e3)
- 팀 삭제하기를 클릭 시 팀 삭제하기 모달이 열립니다.
![image](https://github.com/user-attachments/assets/f4571fe1-1366-48ae-ab6f-392c4d9664d1)
- 관련된 로직은 코드를 참고하시면 될 것 같습니다!


## 리뷰 요구사항

- 혹시 코드를 확인하시고 궁금한게 있으시거나 꼭 수정해야하는 내용이 있다면 comment 남겨주세요~

## 기타

- Closes: #70 
