### PR TITLE
Feat: 팀 페이지 기능 구현 (팀 멤버 목록)

### DIFF
--- a/apis/group.ts
+++ b/apis/group.ts
@@ -46,6 +46,33 @@ export async function acceptInvitation(
   return json;
 }
 
+export async function inviteMemberWithEmail({
+  groupId,
+  email,
+}: {
+  groupId: number;
+  email: string;
+}) {
+  if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email)) {
+    throw new Error("이메일 형식이 올바르지 않습니다.");
+  }
+
+  const res = await fetchExtended(`/groups/${groupId}/member`, {
+    method: "POST",
+    body: JSON.stringify({ userEmail: email }),
+  });
+
+  if (res.status === 204) {
+    return;
+  }
+
+  const json = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message);
+  }
+}
+
 export async function getTeam({
   groupId,
 }: {

--- a/apis/group.ts
+++ b/apis/group.ts
@@ -1,4 +1,5 @@
 import {
+  GenerateInviteTokenResponse,
   AcceptInvitationResponse,
   GetTeamResponse,
   AddTeamResponse,
@@ -9,6 +10,19 @@ import {
 import fetchExtended from "./fetchExtended";
 import { uploadImage } from "./image";
 import { getUser } from "./user";
+
+export async function generateInviteToken(
+  groupId: number,
+): Promise<GenerateInviteTokenResponse> {
+  const res = await fetchExtended(`/groups/${groupId}/invitation`);
+  const json = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message);
+  }
+
+  return json;
+}
 
 export async function acceptInvitation(
   token: string,

--- a/components/team/with_team/MemberCard.tsx
+++ b/components/team/with_team/MemberCard.tsx
@@ -1,0 +1,111 @@
+import Image from "next/image";
+
+import { Button } from "@/@common/Button";
+import Modal from "@/@common/modal/Modal";
+import { Member } from "@/dtos/GroupDtos";
+import { useToast } from "@/hooks/useToast";
+import Kebab from "@/public/svg/kebab.svg";
+
+interface CardProps {
+  member: Member;
+}
+
+function MemberDetailButton({ member }: CardProps) {
+  const { toast } = useToast();
+
+  const handleEmailCopyButtonClick = () => {
+    navigator.clipboard.writeText(member.userEmail);
+
+    (() => toast({ title: "클립보드에 복사되었습니다!" }))();
+  };
+
+  return (
+    <button>
+      <Modal
+        trigger={<Kebab className="shrink-0" width="16" height="16" />}
+        type="modal"
+        footer={
+          <Button className="flex-1" onClick={handleEmailCopyButtonClick}>
+            이메일 복사하기
+          </Button>
+        }
+        hasCrossCloseIcon
+      >
+        <div className="flex flex-col items-center justify-center gap-6">
+          <Image
+            width={52}
+            height={52}
+            src={
+              member.userImage
+                ? member.userImage
+                : "/images/team_page_default_user_pfp.png"
+            }
+            alt="유저 프로필 이미지"
+          />
+          <div className="flex flex-col items-center justify-center gap-2">
+            <h2 className="md-medium text-default-light">{member.userName}</h2>
+            <div className="xs-normal text-default-light">
+              {member.userEmail}
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </button>
+  );
+}
+
+export function MobileMemberCard({ member }: CardProps) {
+  return (
+    <div className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3">
+      <div className="min-w-0">
+        <div className="mb-1 flex items-center gap-2">
+          <Image
+            width={24}
+            height={24}
+            src={
+              member.userImage
+                ? member.userImage
+                : "/images/team_page_default_user_pfp.png"
+            }
+            alt="유저 프로필 이미지"
+          />
+          <div className="md-medium truncate text-default-light">
+            {member.userName}
+          </div>
+        </div>
+        <div className="md-medium truncate text-subText">
+          {member.userEmail}
+        </div>
+      </div>
+      <MemberDetailButton member={member} />
+    </div>
+  );
+}
+
+export function PcMemberCard({ member }: CardProps) {
+  return (
+    <div className="flex h-[73px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3">
+      <div className="flex min-w-0 gap-3">
+        <Image
+          width={32}
+          height={32}
+          src={
+            member.userImage
+              ? member.userImage
+              : "/images/team_page_default_user_pfp.png"
+          }
+          alt="유저 프로필 이미지"
+        />
+        <div className="min-w-0">
+          <div className="md-medium truncate text-default-light">
+            {member.userName}
+          </div>
+          <div className="md-medium truncate text-subText">
+            {member.userEmail}
+          </div>
+        </div>
+      </div>
+      <MemberDetailButton member={member} />
+    </div>
+  );
+}

--- a/components/team/with_team/TeamInviteModalButton.tsx
+++ b/components/team/with_team/TeamInviteModalButton.tsx
@@ -1,0 +1,114 @@
+import { ChangeEvent, MouseEvent, useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/@common/Button";
+import Input from "@/@common/Input";
+import Modal from "@/@common/modal/Modal";
+import { useToast } from "@/hooks/useToast";
+import {
+  useGenerateInviteToken,
+  useInviteMemberWithEmail,
+} from "@/queries/group";
+
+interface TeamInviteModalButtonProps {
+  groupId: number;
+}
+
+export default function TeamInviteModalButton({
+  groupId,
+}: TeamInviteModalButtonProps) {
+  const queryClient = useQueryClient();
+
+  const [userEmailValue, setUserEmailValue] = useState("");
+  const [emailInputErrorMessage, setEmailInputErrorMessage] = useState("");
+
+  const { data: inviteToken } = useGenerateInviteToken(groupId);
+  const { mutate: inviteMemberWithEmail } = useInviteMemberWithEmail();
+
+  const { toast } = useToast();
+
+  // 팀 초대하기 모달의 email input change 핸들러
+  const handleUserEmailInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserEmailValue(e.target.value);
+
+    if (emailInputErrorMessage) {
+      setEmailInputErrorMessage("");
+    }
+  };
+
+  // 이메일 초대 button click 핸들러
+  // 1. 이메일 입력이 없는 경우 api 요청 x + error message
+  // 2. 이외에는 api 요청을 하고 error message를 띄움
+  // 3. 성공시에는 toast를 띄우고 팀 페이지의 팀 멤버 목록 최신화를 위해 invalidateQuery
+  const handleEmailInviteButtonClick = (e: MouseEvent) => {
+    if (!userEmailValue) {
+      e.stopPropagation();
+      setEmailInputErrorMessage("이메일을 입력해주세요.");
+    }
+
+    inviteMemberWithEmail(
+      { groupId, email: userEmailValue },
+      {
+        onError: (error) => {
+          e.stopPropagation(); // error 발생시에 안닫히게 하고 싶으나 동작하지 않음 (이후에 bug fix)
+          setEmailInputErrorMessage(error.message);
+        },
+        onSuccess: () => {
+          (() => toast({ title: "초대에 성공하였습니다." }))();
+          queryClient.invalidateQueries({ queryKey: ["team", groupId] });
+        },
+      },
+    );
+  };
+
+  // 초대 링크를 복사 button handler, 복사 후 토스트를 띄움
+  const handleInviteTokenCopyButton = () => {
+    (() => toast({ title: "초대 링크를 복사하였습니다." }))();
+
+    navigator.clipboard.writeText(
+      `${process.env.NEXT_PUBLIC_DEPLOY_URL}/jointeam?${inviteToken}`,
+    );
+  };
+
+  return (
+    <Modal
+      trigger={
+        <button className="md-medium text-brand-active">
+          + 새로운 멤버 초대하기
+        </button>
+      }
+      title="멤버 초대"
+      description={
+        <>
+          초대 받을 유저의 email을 입력합니다.
+          <br />
+          또는 그룹에 참여할 수 있는 링크를 복사합니다.
+        </>
+      }
+      type="modal"
+      hasCrossCloseIcon
+      footer={
+        <div className="flex w-full flex-col gap-2">
+          <Button className="flex-1" onClick={handleEmailInviteButtonClick}>
+            이메일로 초대하기
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={handleInviteTokenCopyButton}
+          >
+            링크 복사하기
+          </Button>
+        </div>
+      }
+    >
+      <Input
+        value={userEmailValue}
+        onChange={handleUserEmailInputChange}
+        Error={!!emailInputErrorMessage}
+        ErrorMessage={emailInputErrorMessage}
+      />
+    </Modal>
+  );
+}

--- a/components/team/with_team/TeamMemberList.tsx
+++ b/components/team/with_team/TeamMemberList.tsx
@@ -2,8 +2,69 @@
 
 import Image from "next/image";
 
+import { Member } from "@/dtos/GroupDtos";
 import Kebab from "@/public/svg/kebab.svg";
 import { useGetTeam } from "@/queries/group";
+
+interface CardProps {
+  member: Member;
+}
+
+function MobileMemberCard({ member }: CardProps) {
+  return (
+    <div className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]">
+      <div className="min-w-0">
+        <div className="mb-1 flex items-center gap-2">
+          <Image
+            width={24}
+            height={24}
+            src={
+              member.userImage
+                ? member.userImage
+                : "/images/team_page_default_user_pfp.png"
+            }
+            alt="유저 프로필 이미지"
+          />
+          <div className="md-medium truncate text-default-light">
+            {member.userName}
+          </div>
+        </div>
+        <div className="md-medium truncate text-subText">
+          {member.userEmail}
+        </div>
+      </div>
+      <Kebab className="shrink-0" width="16" height="16" />
+    </div>
+  );
+}
+
+function PcMemberCard({ member }: CardProps) {
+  return (
+    <div className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]">
+      <div className="flex min-w-0 gap-3">
+        <Image
+          width={32}
+          height={32}
+          src={
+            member.userImage
+              ? member.userImage
+              : "/images/team_page_default_user_pfp.png"
+          }
+          alt="유저 프로필 이미지"
+        />
+        <div className="min-w-0">
+          <div className="md-medium truncate text-default-light">
+            {member.userName}
+          </div>
+          <div className="md-medium truncate text-subText">
+            {member.userEmail}
+          </div>
+        </div>
+      </div>
+      <Kebab className="shrink-0" width="16" height="16" />
+    </div>
+  );
+}
 
 interface TeamMemberListProps {
   isAdmin: boolean;
@@ -34,64 +95,14 @@ export default function TeamMemberList({
           </button>
         )}
       </h2>
-      <div className="not-mobile-grid hidden grid-cols-3 gap-6 tab:grid">
+      <div className="pc-and-tablet-grid hidden grid-cols-3 gap-6 tab:grid">
         {teamMembers.map((member) => (
-          <div
-            key={member.userEmail}
-            className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]"
-          >
-            <div className="flex min-w-0 gap-3">
-              <Image
-                width={32}
-                height={32}
-                src={
-                  member.userImage
-                    ? member.userImage
-                    : "/images/team_page_default_user_pfp.png"
-                }
-                alt="유저 프로필 이미지"
-              />
-              <div className="min-w-0">
-                <div className="md-medium truncate text-default-light">
-                  {member.userName}
-                </div>
-                <div className="md-medium truncate text-subText">
-                  {member.userEmail}
-                </div>
-              </div>
-            </div>
-            <Kebab className="shrink-0" width="16" height="16" />
-          </div>
+          <PcMemberCard key={member.userEmail} member={member} />
         ))}
       </div>
       <div className="mobile-grid grid grid-cols-2 gap-6 tab:hidden">
         {teamMembers.map((member) => (
-          <div
-            key={member.userEmail}
-            className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]"
-          >
-            <div className="min-w-0">
-              <div className="mb-1 flex items-center gap-2">
-                <Image
-                  width={24}
-                  height={24}
-                  src={
-                    member.userImage
-                      ? member.userImage
-                      : "/images/team_page_default_user_pfp.png"
-                  }
-                  alt="유저 프로필 이미지"
-                />
-                <div className="md-medium truncate text-default-light">
-                  {member.userName}
-                </div>
-              </div>
-              <div className="md-medium truncate text-subText">
-                {member.userEmail}
-              </div>
-            </div>
-            <Kebab className="shrink-0" width="16" height="16" />
-          </div>
+          <MobileMemberCard key={member.userEmail} member={member} />
         ))}
       </div>
     </>

--- a/components/team/with_team/TeamMemberList.tsx
+++ b/components/team/with_team/TeamMemberList.tsx
@@ -3,6 +3,7 @@
 import { useGetTeam } from "@/queries/group";
 
 import { PcMemberCard, MobileMemberCard } from "./MemberCard";
+import TeamInviteModalButton from "./TeamInviteModalButton";
 
 interface TeamMemberListProps {
   isAdmin: boolean;
@@ -27,11 +28,7 @@ export default function TeamMemberList({
             {`(${numberOfMembers}명)`}
           </span>
         </div>
-        {isAdmin && (
-          <button className="md-medium text-brand-active">
-            + 새로운 멤버 초대하기
-          </button>
-        )}
+        {isAdmin && <TeamInviteModalButton groupId={groupId} />}
       </h2>
       <div className="pc-and-tablet-grid hidden grid-cols-3 gap-6 tab:grid">
         {teamMembers.map((member) => (

--- a/components/team/with_team/TeamMemberList.tsx
+++ b/components/team/with_team/TeamMemberList.tsx
@@ -1,32 +1,31 @@
+"use client";
+
 import Image from "next/image";
 
 import Kebab from "@/public/svg/kebab.svg";
-
-const USER_INFO = [
-  {
-    userImage: null,
-    userName: "강미희",
-    userEmail: "Mihee123123123@naver.com",
-  },
-  { userImage: null, userName: "강미희", userEmail: "Mihee@naver.com" },
-  { userImage: null, userName: "강미희", userEmail: "Mihee@naver.com" },
-  { userImage: null, userName: "강미희", userEmail: "Mihee@naver.com" },
-  { userImage: null, userName: "강미희", userEmail: "Mihee@naver.com" },
-  { userImage: null, userName: "강미희", userEmail: "Mihee@naver.com" },
-];
+import { useGetTeam } from "@/queries/group";
 
 interface TeamMemberListProps {
   isAdmin: boolean;
+  groupId: number;
 }
 
-export default function TeamMemberList({ isAdmin }: TeamMemberListProps) {
+export default function TeamMemberList({
+  isAdmin,
+  groupId,
+}: TeamMemberListProps) {
+  const { data } = useGetTeam(groupId);
+
+  const teamMembers = data?.members || [];
+  const numberOfMembers = teamMembers.length;
+
   return (
     <>
       <h2 className="mb-4 flex items-center justify-between pc:mb-5">
         <div className="text-[18px]/[19px] font-semibold text-default-light">
           멤버
           <span className="lg-normal ml-2 text-default-light opacity-80">
-            (6명)
+            {`(${numberOfMembers}명)`}
           </span>
         </div>
         {isAdmin && (
@@ -36,9 +35,9 @@ export default function TeamMemberList({ isAdmin }: TeamMemberListProps) {
         )}
       </h2>
       <div className="not-mobile-grid hidden grid-cols-3 gap-6 tab:grid">
-        {USER_INFO.map((user) => (
+        {teamMembers.map((member) => (
           <div
-            key={user.userEmail}
+            key={member.userEmail}
             className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]"
           >
             <div className="flex min-w-0 gap-3">
@@ -46,18 +45,18 @@ export default function TeamMemberList({ isAdmin }: TeamMemberListProps) {
                 width={32}
                 height={32}
                 src={
-                  user.userImage
-                    ? user.userImage
+                  member.userImage
+                    ? member.userImage
                     : "/images/team_page_default_user_pfp.png"
                 }
                 alt="유저 프로필 이미지"
               />
               <div className="min-w-0">
                 <div className="md-medium truncate text-default-light">
-                  {user.userName}
+                  {member.userName}
                 </div>
                 <div className="md-medium truncate text-subText">
-                  {user.userEmail}
+                  {member.userEmail}
                 </div>
               </div>
             </div>
@@ -66,9 +65,9 @@ export default function TeamMemberList({ isAdmin }: TeamMemberListProps) {
         ))}
       </div>
       <div className="mobile-grid grid grid-cols-2 gap-6 tab:hidden">
-        {USER_INFO.map((user) => (
+        {teamMembers.map((member) => (
           <div
-            key={user.userEmail}
+            key={member.userEmail}
             className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]"
           >
             <div className="min-w-0">
@@ -77,18 +76,18 @@ export default function TeamMemberList({ isAdmin }: TeamMemberListProps) {
                   width={24}
                   height={24}
                   src={
-                    user.userImage
-                      ? user.userImage
+                    member.userImage
+                      ? member.userImage
                       : "/images/team_page_default_user_pfp.png"
                   }
                   alt="유저 프로필 이미지"
                 />
                 <div className="md-medium truncate text-default-light">
-                  {user.userName}
+                  {member.userName}
                 </div>
               </div>
               <div className="md-medium truncate text-subText">
-                {user.userEmail}
+                {member.userEmail}
               </div>
             </div>
             <Kebab className="shrink-0" width="16" height="16" />

--- a/components/team/with_team/TeamMemberList.tsx
+++ b/components/team/with_team/TeamMemberList.tsx
@@ -1,70 +1,8 @@
 "use client";
 
-import Image from "next/image";
-
-import { Member } from "@/dtos/GroupDtos";
-import Kebab from "@/public/svg/kebab.svg";
 import { useGetTeam } from "@/queries/group";
 
-interface CardProps {
-  member: Member;
-}
-
-function MobileMemberCard({ member }: CardProps) {
-  return (
-    <div className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]">
-      <div className="min-w-0">
-        <div className="mb-1 flex items-center gap-2">
-          <Image
-            width={24}
-            height={24}
-            src={
-              member.userImage
-                ? member.userImage
-                : "/images/team_page_default_user_pfp.png"
-            }
-            alt="유저 프로필 이미지"
-          />
-          <div className="md-medium truncate text-default-light">
-            {member.userName}
-          </div>
-        </div>
-        <div className="md-medium truncate text-subText">
-          {member.userEmail}
-        </div>
-      </div>
-      <Kebab className="shrink-0" width="16" height="16" />
-    </div>
-  );
-}
-
-function PcMemberCard({ member }: CardProps) {
-  return (
-    <div className="flex h-[68px] items-center justify-between rounded-2xl bg-brand-secondary-light px-6 py-3 tab:h-[73px]">
-      <div className="flex min-w-0 gap-3">
-        <Image
-          width={32}
-          height={32}
-          src={
-            member.userImage
-              ? member.userImage
-              : "/images/team_page_default_user_pfp.png"
-          }
-          alt="유저 프로필 이미지"
-        />
-        <div className="min-w-0">
-          <div className="md-medium truncate text-default-light">
-            {member.userName}
-          </div>
-          <div className="md-medium truncate text-subText">
-            {member.userEmail}
-          </div>
-        </div>
-      </div>
-      <Kebab className="shrink-0" width="16" height="16" />
-    </div>
-  );
-}
+import { PcMemberCard, MobileMemberCard } from "./MemberCard";
 
 interface TeamMemberListProps {
   isAdmin: boolean;

--- a/components/team/with_team/WithTeam.tsx
+++ b/components/team/with_team/WithTeam.tsx
@@ -20,7 +20,7 @@ export default function WithTeam({ isAdmin, groupId }: WithTeamProps) {
         </div>
         {isAdmin && <TeamReport />}
         <div className="mt-12 pc:mt-8">
-          <TeamMemberList isAdmin={isAdmin} />
+          <TeamMemberList isAdmin={isAdmin} groupId={groupId} />
         </div>
       </div>
     </Container>

--- a/dtos/GroupDtos.ts
+++ b/dtos/GroupDtos.ts
@@ -1,3 +1,5 @@
+export type GenerateInviteTokenResponse = string;
+
 export interface AcceptInvitationResponse {
   groupId: number;
 }

--- a/dtos/GroupDtos.ts
+++ b/dtos/GroupDtos.ts
@@ -2,7 +2,7 @@ export interface AcceptInvitationResponse {
   groupId: number;
 }
 
-interface Member {
+export interface Member {
   role: "ADMIN" | "MEMBER";
   userImage: string | null;
   userEmail: string;

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -6,7 +6,15 @@ import {
   addTeam,
   editTeam,
   delTeam,
+  generateInviteToken,
 } from "@/apis/group";
+
+export function useGenerateInviteToken(groupId: number) {
+  return useQuery({
+    queryKey: ["inviteToken", groupId],
+    queryFn: () => generateInviteToken(groupId),
+  });
+}
 
 export function useAcceptInvitation() {
   return useMutation({

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 
 import {
   acceptInvitation,
+  inviteMemberWithEmail,
   getTeam,
   addTeam,
   editTeam,
@@ -19,6 +20,13 @@ export function useGenerateInviteToken(groupId: number) {
 export function useAcceptInvitation() {
   return useMutation({
     mutationFn: (token: string) => acceptInvitation(token),
+  });
+}
+
+export function useInviteMemberWithEmail() {
+  return useMutation({
+    mutationFn: ({ groupId, email }: { groupId: number; email: string }) =>
+      inviteMemberWithEmail({ groupId, email }),
   });
 }
 


### PR DESCRIPTION
## 작업 내용

- 팀 페이지 중 팀 멤버 목록 컴포넌트를 구현하였습니다.
- 멤버 카드의 케밥 버튼을 누르면 팀 멤버의 정보를 띄워주는 모달이 열립니다.
![image](https://github.com/user-attachments/assets/9a46c4aa-bffd-4a48-b5f3-4e8f29b2f121)
- 해당 모달의 이메일 복사하기 버튼을 누르면 복사에 성공했다는 토스트가 뜨고 클립보드에 이메일이 복사됩니다.
- 팀 페이지의 관리자인 경우에 팀 멤버 목록 우측 상단에 새로운 멤버 초대하기 버튼이 뜹니다.
![image](https://github.com/user-attachments/assets/ebde131a-3bbc-409b-b9aa-1f4b8a4e2658)
- 해당 버튼을 누르면 아래와 같은 모달이 뜹니다.
![image](https://github.com/user-attachments/assets/ca944452-43f5-4998-ab0b-436f5ac53cf7)
- 초대하고자 하는 유저의 이메일을 입력하고 이메일로 초대하기 버튼을 누르면 해당 유저를 팀에 초대합니다.
- 링크 복사하기 버튼을 누르면 복사에 성공했다는 토스트가 뜨고 클립보드에 링크가 복사됩니다. 해당 링크는 팀 참여하기 링크로 이동하는 링크이며 이후 동작은 다시 구현될 예정입니다.


## 리뷰 요구사항

- 혹시 따로 궁금하신점이 있으면 말해주세요

## 기타

- Closes #71 
