### PR TITLE
Fix: 팀 참여 페이지 로직 수정 #99

### DIFF
--- a/app/(pages)/(team)/jointeam/page.tsx
+++ b/app/(pages)/(team)/jointeam/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, ChangeEvent, FormEvent } from "react";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/@common/Button";
 import Input from "@/components/@common/Input";
@@ -12,7 +12,12 @@ import { revalidateLayout } from "@/lib/revalidate";
 import { useAcceptInvitation } from "@/queries/group";
 
 export default function JoinTeamPage() {
-  const [teamToken, setTeamToken] = useState("");
+  const searchParams = useSearchParams();
+  const defaultInputValue = searchParams.get("invite")
+    ? `${process.env.NEXT_PUBLIC_DEPLOY_URL}/jointeam?invite=${searchParams.get("invite")}`
+    : "";
+
+  const [teamInviteLink, setTeamInviteLink] = useState(defaultInputValue);
   const [inputErrorMessage, setInputErrorMessage] = useState("");
 
   const { mutate: acceptInvitation } = useAcceptInvitation();
@@ -22,7 +27,7 @@ export default function JoinTeamPage() {
 
   // token input이 변경되었을 때, input의 error message를 상태로 관리해서 변경해주는 핸들러
   const handleTokenInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTeamToken(e.target.value);
+    setTeamInviteLink(e.target.value);
 
     if (inputErrorMessage) {
       setInputErrorMessage("");
@@ -33,16 +38,23 @@ export default function JoinTeamPage() {
   const handleTokenSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!teamToken) {
-      setInputErrorMessage("토큰을 입력해주세요!");
+    if (!teamInviteLink) {
+      setInputErrorMessage("초대 링크를 입력해주세요.");
       return;
     }
 
-    acceptInvitation(teamToken, {
+    const matchInviteToken = teamInviteLink.match(/invite=([^&]*)/);
+    if (!matchInviteToken) {
+      setInputErrorMessage("초대 링크가 올바르지 않은 형식입니다.");
+      return;
+    }
+    const inviteToken = matchInviteToken[1];
+
+    acceptInvitation(inviteToken, {
       onError: (error) => {
         if (error.message === "jwt expired") {
           setInputErrorMessage(
-            "초대 토큰이 만료되었습니다. 재발급이 필요합니다.",
+            "초대 링크가 만료되었습니다. 재발급이 필요합니다.",
           );
         } else {
           setInputErrorMessage(error.message);
@@ -68,21 +80,21 @@ export default function JoinTeamPage() {
           팀 참여하기
         </h1>
         <label htmlFor="token">
-          <h3 className="lg-medium mb-3 text-default-light">팀 링크</h3>
+          <h3 className="lg-medium mb-3 text-default-light">초대 링크</h3>
         </label>
         <Input
           id="token"
           Error={!!inputErrorMessage}
           ErrorMessage={inputErrorMessage}
           onChange={handleTokenInputChange}
-          placeholder="팀 토큰을 입력해주세요."
-          value={teamToken}
+          placeholder="팀 초대 링크를 입력해주세요."
+          value={teamInviteLink}
         />
         <Button className="mb-6 mt-10 w-full" type="submit">
           참여하기
         </Button>
         <p className="lg-normal text-center text-default-light">
-          공유받은 팀 토큰을 입력해 참여할 수 있어요.
+          공유받은 초대 링크를 입력해 참여할 수 있어요.
         </p>
       </form>
     </Container>

--- a/components/team/with_team/TeamInviteModalButton.tsx
+++ b/components/team/with_team/TeamInviteModalButton.tsx
@@ -67,7 +67,7 @@ export default function TeamInviteModalButton({
     (() => toast({ title: "초대 링크를 복사하였습니다." }))();
 
     navigator.clipboard.writeText(
-      `${process.env.NEXT_PUBLIC_DEPLOY_URL}/jointeam?${inviteToken}`,
+      `${process.env.NEXT_PUBLIC_DEPLOY_URL}/jointeam?invite=${inviteToken}`,
     );
   };
 


### PR DESCRIPTION
## 작업 내용

- 팀 초대 페이지의 로직을 자연스럽게 수정하였습니다.
1. 팀 초대 링크 발급 시 invite query가 있는 팀 초대 페이지 링크를 발급합니다.
2. 팀 초대 링크 url로 이동 시 invite query값이 있는 경우 input의 default value로 해당 링크를 set합니다.
3. input 값 중 invite query의 value (token)만 추출 하여 api 요청을 전송하도록 수정하였습니다.

## 리뷰 요구사항

- 혹시 테스트 하고 싶으시다면 테스트 해보시고 궁금한게 있으면 comment로 달아주세요!

## 기타

- Closes #99 
