### PR TITLE
fix/design: 팀 페이지 및 팀 생성하기 페이지 디자인 수정

### DIFF
--- a/components/team/add_team/TeamImageInput.tsx
+++ b/components/team/add_team/TeamImageInput.tsx
@@ -36,7 +36,7 @@ export default function TeamImageInput({
           className="mb-6 inline-block cursor-pointer pc:mx-auto"
         >
           <h3 className="lg-medium text-default-light pc:hidden">팀 프로필</h3>
-          <div className="relative mx-auto mt-3 h-[64px] w-[64px] pc:h-[147px] pc:w-[147px]">
+          <div className="relative mt-3 h-[64px] w-[64px] pc:mx-auto pc:h-[147px] pc:w-[147px]">
             {previewImage ? (
               <>
                 <Image

--- a/components/team/with_team/MemberCard.tsx
+++ b/components/team/with_team/MemberCard.tsx
@@ -22,7 +22,7 @@ function MemberDetailButton({ member }: CardProps) {
   return (
     <button>
       <Modal
-        trigger={<Kebab className="shrink-0" width="16" height="16" />}
+        trigger={<Kebab className="shrink-0" width="24" height="24" />}
         type="modal"
         footer={
           <Button className="flex-1" onClick={handleEmailCopyButtonClick}>
@@ -62,6 +62,8 @@ export function MobileMemberCard({ member }: CardProps) {
           <Image
             width={24}
             height={24}
+            className="aspect-square rounded-full"
+            objectFit="cover"
             src={
               member.userImage
                 ? member.userImage
@@ -89,6 +91,8 @@ export function PcMemberCard({ member }: CardProps) {
         <Image
           width={32}
           height={32}
+          className="aspect-square rounded-full"
+          objectFit="cover"
           src={
             member.userImage
               ? member.userImage

--- a/components/team/with_team/TeamTaskListCard.tsx
+++ b/components/team/with_team/TeamTaskListCard.tsx
@@ -54,7 +54,7 @@ export default function TeamTaskListCard({
           {taskList.name}
         </Link>
         <div className="flex shrink-0 items-center">
-          <div className="flex h-[25px] items-center justify-between gap-1 rounded-full bg-brand-secondary-light px-2 py-1">
+          <div className="flex h-[25px] min-w-16 items-center justify-between gap-1 rounded-full bg-brand-secondary-light px-2 py-1">
             {isCompletedTaskList ? <ProgressComplete /> : <ProgressCircle />}
             <div>{`${doneTaskCount}/${totalTaskCount}`}</div>
           </div>
@@ -63,10 +63,10 @@ export default function TeamTaskListCard({
               onEditHandler={toggleIsEditModalOpen}
               onDeleteHandler={toggleIsDelModalOpen}
             >
-              <Kebab width="16" height="16" />
+              <Kebab width="20" height="20" />
             </ActionsDropDown>
           ) : (
-            <Kebab width="16" height="16" />
+            <Kebab width="20" height="20" />
           )}
         </div>
       </div>

--- a/components/team/with_team/TodoReportChartSide.tsx
+++ b/components/team/with_team/TodoReportChartSide.tsx
@@ -15,7 +15,7 @@ export default function TodoReportChartSide({
 }: TodoReportChartSideProps) {
   const dataTasksCount = tasksCount ? tasksCount - doneTasksCount : 1;
   const progressPercentage = tasksCount
-    ? (doneTasksCount / tasksCount) * 100
+    ? Math.ceil((doneTasksCount / tasksCount) * 100)
     : 0;
 
   const chartData = {


### PR DESCRIPTION
## 작업 내용

- 팀 페이지 및 팀 생성하기 페이지의 UI 디자인 관련 문제를 수정하였습니다.
1. 팀 생성하기 페이지 image input error message로 인한 image input의 이동
![image](https://github.com/user-attachments/assets/db8992af-5c68-40bc-b0ea-04ad3fd48248)
2. 팀 페이지 그래프 소숫점이 표시되는 문제
3. 팀 멤버 프로필 이미지에 rounded 처리 누락
4. 할 일 목록 리스트에 min-width 필요
![image](https://github.com/user-attachments/assets/33f2ade5-914a-4ff2-8753-00f495af6e28)
5. 케밥 버튼의 크기 수정 (기존 16px -> 이후 24px)

## 리뷰 요구사항

- 간단한 디자인 수정입니다! 별 다른 문제는 없습니다~

## 기타

- Closes #130 
