### PR TITLE
Fix: 1차 할 일 상세 페이지 수정

### DIFF
--- a/components/taskdetail/DeleteCommentModal.tsx
+++ b/components/taskdetail/DeleteCommentModal.tsx
@@ -1,4 +1,3 @@
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/@common/Button";
@@ -50,8 +49,6 @@ export default function DeleteCommentModal({
       type="modal"
       trigger={isOpen}
       onOpenChange={toggleIsOpen}
-      title={<VisuallyHidden.Root>댓글 삭제</VisuallyHidden.Root>}
-      description={<VisuallyHidden.Root>댓글 삭제</VisuallyHidden.Root>}
       footer={
         <>
           <Button className="flex-1" variant="outlinedSecondary">

--- a/components/taskdetail/DeleteTaskModal.tsx
+++ b/components/taskdetail/DeleteTaskModal.tsx
@@ -44,7 +44,7 @@ export default function DeleteTaskModal({
             }))();
         },
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ["taskList"] });
+          queryClient.removeQueries({ queryKey: ["taskList"] });
           router.back();
         },
       },

--- a/components/taskdetail/EditTaskModal.tsx
+++ b/components/taskdetail/EditTaskModal.tsx
@@ -1,6 +1,5 @@
 import { MouseEvent, ChangeEvent, useState, useEffect } from "react";
 
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/@common/Button";
@@ -108,8 +107,6 @@ export default function EditTaskModal({
       type="modal"
       trigger={isOpen}
       onOpenChange={toggleIsOpen}
-      title={<VisuallyHidden.Root />}
-      description={<VisuallyHidden.Root />}
       footer={
         <>
           <Button className="flex-1" variant="outlinedSecondary">

--- a/components/taskdetail/EditTaskModal.tsx
+++ b/components/taskdetail/EditTaskModal.tsx
@@ -55,22 +55,22 @@ export default function EditTaskModal({
 
   const handleEditTask = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (taskData.name === "") {
+    if (taskData.name.trim() === "") {
       e.stopPropagation();
       setErrorMessage("할 일 제목을 입력해주세요.");
       return;
     }
-    if (taskData.name.length > 30) {
+    if (taskData.name.trim().length > 30) {
       e.stopPropagation();
       setErrorMessage("제목은 30자 미만으로 작성해주세요.");
       return;
     }
-    if (taskData.description === "") {
+    if (taskData.description.trim() === "") {
       e.stopPropagation();
       setErrorMessage("할 일 메모를 입력해주세요.");
       return;
     }
-    if (taskData.description.length > 255) {
+    if (taskData.description.trim().length > 255) {
       e.stopPropagation();
       setErrorMessage("255자 미만으로 작성해주세요.");
       return;

--- a/components/taskdetail/EditTaskModal.tsx
+++ b/components/taskdetail/EditTaskModal.tsx
@@ -60,9 +60,19 @@ export default function EditTaskModal({
       setErrorMessage("할 일 제목을 입력해주세요.");
       return;
     }
+    if (taskData.name.length > 30) {
+      e.stopPropagation();
+      setErrorMessage("제목은 30자 미만으로 작성해주세요.");
+      return;
+    }
     if (taskData.description === "") {
       e.stopPropagation();
       setErrorMessage("할 일 메모를 입력해주세요.");
+      return;
+    }
+    if (taskData.description.length > 255) {
+      e.stopPropagation();
+      setErrorMessage("255자 미만으로 작성해주세요.");
       return;
     }
     const requestData = {

--- a/components/taskdetail/TaskComment.tsx
+++ b/components/taskdetail/TaskComment.tsx
@@ -104,6 +104,7 @@ export default function TaskComment({ comment, userId }: TaskCommentProps) {
                     height={32}
                     src={comment.user.image}
                     alt={`${comment.user.nickname} 프로필`}
+                    className="rounded-full"
                   />
                 ) : (
                   <Image

--- a/components/taskdetail/TaskCommentForm.tsx
+++ b/components/taskdetail/TaskCommentForm.tsx
@@ -43,7 +43,7 @@ export default function TaskCommentForm({ taskid }: { taskid: string }) {
         />
         <button
           disabled={!content}
-          className="mr-[12px] inline-block h-[24px] w-[24px] rounded-full bg-brand-primary-light p-1 disabled:bg-[#888888]"
+          className="mr-[12px] inline-block h-[22px] w-[24px] rounded-full bg-brand-primary-light p-1 disabled:bg-[#888888]"
         >
           <span>
             <Image

--- a/components/taskdetail/TaskCommentList.tsx
+++ b/components/taskdetail/TaskCommentList.tsx
@@ -12,13 +12,18 @@ export default function TaskCommentList({
   userId: number;
 }) {
   const { data, isLoading } = useGetTaskComment(taskid);
+
   return (
     <div className="mt-[32px]">
-      {data &&
-        !isLoading &&
+      {data && !isLoading && data.length > 0 ? (
         data.map((list) => (
           <TaskComment key={list.id} comment={list} userId={userId} />
-        ))}
+        ))
+      ) : (
+        <div className="flex items-center justify-center">
+          <p>댓글이 없습니다.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/taskdetail/TaskDetail.tsx
+++ b/components/taskdetail/TaskDetail.tsx
@@ -63,6 +63,7 @@ export default function TaskDetail({ data, userId }: TaskDetailProps) {
                 height={32}
                 src={data.writer.image}
                 alt={`${data.writer.nickname} 프로필`}
+                className="rounded-full"
               />
             ) : (
               <Image
@@ -70,6 +71,7 @@ export default function TaskDetail({ data, userId }: TaskDetailProps) {
                 height={32}
                 src="/images/default_userImage.png"
                 alt={`${data.writer?.nickname} 프로필`}
+                className="rounded-full"
               />
             )}
             <span>{data?.writer?.nickname}</span>

--- a/components/taskdetail/TaskSheet.tsx
+++ b/components/taskdetail/TaskSheet.tsx
@@ -81,9 +81,12 @@ export default function TaskSheet({
   };
 
   const handleRoute = () => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       router.back();
-    }, 500);
+    }, 300);
+    return () => {
+      clearTimeout(timer);
+    };
   };
 
   return (

--- a/components/taskdetail/TaskSheet.tsx
+++ b/components/taskdetail/TaskSheet.tsx
@@ -81,7 +81,9 @@ export default function TaskSheet({
   };
 
   const handleRoute = () => {
-    router.back();
+    setTimeout(() => {
+      router.back();
+    }, 500);
   };
 
   return (

--- a/components/tasks/taskList/TaskCard.tsx
+++ b/components/tasks/taskList/TaskCard.tsx
@@ -1,10 +1,11 @@
+import dayjs from "dayjs";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 
 import { getFrequencyType } from "@/constants/frequencyType";
 import { TasksType } from "@/dtos/TaskDtos";
-import { formatToKorDate } from "@/utils/convertDate";
+import { formatToKorDate, formatToHyphenDate } from "@/utils/convertDate";
 
 interface TaskListProps {
   task: TasksType;
@@ -13,7 +14,7 @@ interface TaskListProps {
 export default function TaskCard({ task }: TaskListProps) {
   const { teamid, tasklistid } = useParams();
   const searchParams = useSearchParams();
-  const date = searchParams.get("date");
+  const date = searchParams.get("date") ?? formatToHyphenDate(dayjs());
   return (
     <article className="flex w-full flex-col gap-2.5 rounded-xl bg-dropDown-default px-3.5 py-3">
       <div className="flex items-center gap-3">

--- a/components/tasks/taskList/TaskCard.tsx
+++ b/components/tasks/taskList/TaskCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 
 import { getFrequencyType } from "@/constants/frequencyType";
 import { TasksType } from "@/dtos/TaskDtos";
@@ -12,6 +12,8 @@ interface TaskListProps {
 
 export default function TaskCard({ task }: TaskListProps) {
   const { teamid, tasklistid } = useParams();
+  const searchParams = useSearchParams();
+  const date = searchParams.get("date");
   return (
     <article className="flex w-full flex-col gap-2.5 rounded-xl bg-dropDown-default px-3.5 py-3">
       <div className="flex items-center gap-3">
@@ -31,7 +33,10 @@ export default function TaskCard({ task }: TaskListProps) {
               alt="체크박스"
             />
           )}
-          <Link href={`/${teamid}/tasks/${tasklistid}/task/${task.id}`}>
+          <Link
+            href={`/${teamid}/tasks/${tasklistid}/task/${task.id}?date=${date}`}
+            scroll={false}
+          >
             <h2 className={`text-md ${task.doneAt && "line-through"}`}>
               {task.name}
             </h2>

--- a/queries/task.ts
+++ b/queries/task.ts
@@ -44,7 +44,7 @@ export function useGetDetailTask(
   taskid: string,
 ) {
   return useQuery({
-    queryKey: ["taskList"],
+    queryKey: ["taskList", teamid, tasklistid, taskid],
     queryFn: () => getDetailTask({ teamid, tasklistid, taskid }),
   });
 }


### PR DESCRIPTION
## 작업 내용

- 할 일 수정 시 제목, 메모에 대한 유효성 검사 로직 추가 (제목 30자, 메모 255자)
- 프로필 이미지 라운드 처리
- 상세 페이지가 닫힐 때 지연 시간 추가 (애니메이션 재생을 위함)
- 상세 페이지를 불러오는 react-query에 taskid key 값 추가
- 다음 페이지에 있는 할 일 목록에 상세 페이지를 볼 때 오늘 날짜의 목록이 보여 date 값을 유지 할 수 있도록 searchParams 추가
- 댓글이 없을 때 문구 추가
- 게시글 삭제 시 network error가 뜨는 현상 수정 (invalidateQueries -> removeQueries)

## 리뷰 요구사항

- 페이지에 대한 에러 사항이 전부 처리 된 건 아닙니당

## 기타

- 기타 참고, 요구 사항을 작성해주세요
- 이미지 첨부 (선택)
- 관련된 이슈가 있다면, PR 작성 맨 아래에서 이슈 연결 키워드도 작성해 주세요.
- #132
