### PR TITLE
Fix: 팀 페이지 데이터 최신화 문제 수정

### DIFF
--- a/components/team/with_team/TeamMemberList.tsx
+++ b/components/team/with_team/TeamMemberList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGetTeam } from "@/queries/group";
+import { GetTeamResponse } from "@/dtos/GroupDtos";
 
 import { PcMemberCard, MobileMemberCard } from "./MemberCard";
 import TeamInviteModalButton from "./TeamInviteModalButton";
@@ -8,15 +8,15 @@ import TeamInviteModalButton from "./TeamInviteModalButton";
 interface TeamMemberListProps {
   isAdmin: boolean;
   groupId: number;
+  teamData: GetTeamResponse | undefined;
 }
 
 export default function TeamMemberList({
   isAdmin,
   groupId,
+  teamData,
 }: TeamMemberListProps) {
-  const { data } = useGetTeam(groupId);
-
-  const teamMembers = data?.members || [];
+  const teamMembers = teamData?.members || [];
   const numberOfMembers = teamMembers.length;
 
   return (

--- a/components/team/with_team/TeamReport.tsx
+++ b/components/team/with_team/TeamReport.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 
-import { useGetTeam } from "@/queries/group";
+import { GetTeamResponse } from "@/dtos/GroupDtos";
 import { countTaskList } from "@/utils/countDoneTask";
 
 import TodoReportChartSide from "./TodoReportChartSide";
@@ -28,13 +28,11 @@ function TeamTodoReportBox({ title, count, imgSrc }: TeamTodoReportBoxProps) {
 }
 
 interface TeamReportProps {
-  groupId: number;
+  teamData: GetTeamResponse | undefined;
 }
 
-export default function TeamReport({ groupId }: TeamReportProps) {
-  const { data } = useGetTeam(groupId);
-
-  const taskLists = data?.taskLists || [];
+export default function TeamReport({ teamData }: TeamReportProps) {
+  const taskLists = teamData?.taskLists || [];
   const { totalDoneTasks: doneTasksCount, totalTasks: tasksCount } =
     countTaskList(taskLists);
 

--- a/components/team/with_team/TeamTitle.tsx
+++ b/components/team/with_team/TeamTitle.tsx
@@ -9,26 +9,31 @@ import { Button } from "@/@common/Button";
 import Input from "@/@common/Input";
 import ActionsDropDown from "@/@common/dropdown/ActionsDropDown";
 import Modal from "@/@common/modal/Modal";
+import { GetTeamResponse } from "@/dtos/GroupDtos";
 import { useToast } from "@/hooks/useToast";
 import useToggle from "@/hooks/useToggle";
 import { revalidateLayout } from "@/lib/revalidate";
 import Sawtooth from "@/public/svg/sawtooth.svg";
 import Warning from "@/public/svg/warning.svg";
-import { useDelTeam, useEditTeam, useGetTeam } from "@/queries/group";
+import { useDelTeam, useEditTeam } from "@/queries/group";
 
 interface TeamTitleProps {
   isAdmin: boolean;
   groupId: number;
+  teamData: GetTeamResponse | undefined;
 }
 
-export default function TeamTitle({ isAdmin, groupId }: TeamTitleProps) {
+export default function TeamTitle({
+  isAdmin,
+  groupId,
+  teamData,
+}: TeamTitleProps) {
   const queryClient = useQueryClient();
 
   const [isEditModalOpen, toggleIsEditModalOpen] = useToggle(false);
   const [isDelModalOpen, toggleIsDelModalOpen] = useToggle(false);
 
-  // string | undefined로 추론되기 때문에 우선은 as string으로 처리하였으나 useGetTeam에서 에러 처리를 하게 되면 필요 없어짐
-  const { data: teamData } = useGetTeam(groupId);
+  // string | undefined로 추론되기 때문에 우선은 as string으로 처리하였으나 error처리 이후에 수정 필요
   const imageUrl = teamData?.image as string;
   const currentTeamName = teamData?.name as string;
 

--- a/components/team/with_team/TeamTodoList.tsx
+++ b/components/team/with_team/TeamTodoList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGetTeam } from "@/queries/group";
+import { GetTeamResponse } from "@/dtos/GroupDtos";
 
 import TeamTaskListAddModalButton from "./TeamTaskListAddModalButton";
 import TeamTaskListCard from "./TeamTaskListCard";
@@ -8,12 +8,15 @@ import TeamTaskListCard from "./TeamTaskListCard";
 interface TeamTodoListProps {
   isAdmin: boolean;
   groupId: number;
+  teamData: GetTeamResponse | undefined;
 }
 
-export default function TeamTodoList({ isAdmin, groupId }: TeamTodoListProps) {
-  const { data } = useGetTeam(groupId);
-
-  const taskLists = data?.taskLists || [];
+export default function TeamTodoList({
+  isAdmin,
+  groupId,
+  teamData,
+}: TeamTodoListProps) {
+  const taskLists = teamData?.taskLists || [];
   const numberOfTaskLists = taskLists.length;
 
   return (

--- a/components/team/with_team/WithTeam.tsx
+++ b/components/team/with_team/WithTeam.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+
 import Container from "@/components/@common/container/Container";
 import { useGetTeam } from "@/queries/group";
 
@@ -14,7 +18,15 @@ interface WithTeamProps {
 }
 
 export default function WithTeam({ isAdmin, groupId }: WithTeamProps) {
-  const { data } = useGetTeam(groupId);
+  const queryClient = useQueryClient();
+
+  const { data } = useGetTeam(groupId, "always");
+
+  // 팀 페이지에 들어올 때 마다 useEffect를 이용해 쿼리를 무효화
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["team", groupId] });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId]);
 
   return (
     <Container background="white">

--- a/components/team/with_team/WithTeam.tsx
+++ b/components/team/with_team/WithTeam.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Container from "@/components/@common/container/Container";
+import { useGetTeam } from "@/queries/group";
 
 import TeamMemberList from "./TeamMemberList";
 import TeamReport from "./TeamReport";
@@ -11,16 +14,18 @@ interface WithTeamProps {
 }
 
 export default function WithTeam({ isAdmin, groupId }: WithTeamProps) {
+  const { data } = useGetTeam(groupId);
+
   return (
     <Container background="white">
       <div className="pb-6 pt-6 pc:pb-8 pc:pt-8">
-        <TeamTitle isAdmin={isAdmin} groupId={groupId} />
+        <TeamTitle isAdmin={isAdmin} groupId={groupId} teamData={data} />
         <div className="mb-12 mt-6 pc:mb-8 pc:mt-8">
-          <TeamTodoList isAdmin={isAdmin} groupId={groupId} />
+          <TeamTodoList isAdmin={isAdmin} groupId={groupId} teamData={data} />
         </div>
-        {isAdmin && <TeamReport groupId={groupId} />}
+        {isAdmin && <TeamReport teamData={data} />}
         <div className="mt-12 pc:mt-8">
-          <TeamMemberList isAdmin={isAdmin} groupId={groupId} />
+          <TeamMemberList isAdmin={isAdmin} groupId={groupId} teamData={data} />
         </div>
       </div>
     </Container>

--- a/queries/group.ts
+++ b/queries/group.ts
@@ -30,10 +30,14 @@ export function useInviteMemberWithEmail() {
   });
 }
 
-export function useGetTeam(groupId: number) {
+export function useGetTeam(
+  groupId: number,
+  refetchOnWindowFocus: boolean | "always" = true,
+) {
   return useQuery({
     queryKey: ["team", groupId],
     queryFn: () => getTeam({ groupId }),
+    refetchOnWindowFocus,
   });
 }
 


### PR DESCRIPTION
## 작업 내용

- 팀 페이지 데이터 최신화 문제를 해결하였습니다.
1. 해당 페이지에 접속시 useEffect를 통해 query를 무효화 시켜 refetch합니다.
2. 다른 window를 보다가 해당 페이지의 window에 focus하는 경우 refetch합니다.

## 리뷰 요구사항

- 혹시 궁금하신 내용이 있으시면 알려주세요!
- 데이터 최신화를 어떻게 했는지 궁금하시다면 [커밋을 참고해주세요](https://github.com/Codeit-FE08-Part4-Team7/wedo/pull/144/commits/2a4085382fc5c664c256baa75087c5c323064e50)

## 기타

- Closes #137
- 커밋에 이슈 번호를 깜빡했네요 ㅠㅠ
