### PR TITLE
Feat: 새로운 공통 모달 컴포넌트 구현

### DIFF
--- a/components/@common/modal/NewModal.tsx
+++ b/components/@common/modal/NewModal.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import * as React from "react";
+
+import * as ModalPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+
+import { cn } from "@/lib/utils";
+
+const Modal = ModalPrimitive.Root;
+
+const ModalTrigger = ModalPrimitive.Trigger;
+
+const ModalPortal = ModalPrimitive.Portal;
+
+const ModalClose = ModalPrimitive.Close;
+
+const ModalOverlay = React.forwardRef<
+  React.ElementRef<typeof ModalPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof ModalPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <ModalPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    onClick={(e) => e.preventDefault()}
+    {...props}
+  />
+));
+ModalOverlay.displayName = ModalPrimitive.Overlay.displayName;
+
+const ModalContent = React.forwardRef<
+  React.ElementRef<typeof ModalPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ModalPrimitive.Content> & {
+    hasCrossCloseIcon?: boolean;
+    type?: "modal" | "alert";
+  }
+>(
+  (
+    {
+      className,
+      children,
+      hasCrossCloseIcon = false,
+      type = "modal",
+      ...props
+    },
+    ref,
+  ) => {
+    const handleInteractOutside = (e: Event) => {
+      if (type === "modal") return;
+      e.preventDefault();
+    };
+
+    return (
+      <ModalPortal>
+        <ModalOverlay />
+        <ModalPrimitive.Content
+          ref={ref}
+          className={cn(
+            "fixed inset-x-0 bottom-0 z-50 grid gap-6 rounded-t-xl border-t bg-inverse px-12 pb-8 pt-12 text-default-light shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom tab:inset-auto tab:left-[50%] tab:top-[50%] tab:w-full tab:max-w-96 tab:translate-x-[-50%] tab:translate-y-[-50%] tab:rounded-xl tab:data-[state=closed]:duration-200 tab:data-[state=open]:duration-200 tab:data-[state=closed]:slide-out-to-left-1/2 tab:data-[state=closed]:slide-out-to-top-[48%] tab:data-[state=open]:slide-in-from-left-1/2 tab:data-[state=open]:slide-in-from-top-[48%]",
+            className,
+          )}
+          onInteractOutside={handleInteractOutside}
+          {...props}
+        >
+          {children}
+          {hasCrossCloseIcon && (
+            <ModalPrimitive.Close className="absolute right-6 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-zinc-100 data-[state=open]:text-zinc-50">
+              <Cross2Icon className="h-6 w-6" />
+              <span className="sr-only">Close</span>
+            </ModalPrimitive.Close>
+          )}
+        </ModalPrimitive.Content>
+      </ModalPortal>
+    );
+  },
+);
+ModalContent.displayName = ModalPrimitive.Content.displayName;
+
+const ModalHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-2 text-center", className)}
+    {...props}
+  />
+);
+ModalHeader.displayName = "DialogHeader";
+
+const ModalFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <ModalPrimitive.Close className="cursor-pointer" asChild>
+    <div
+      className={cn(
+        "flex items-center justify-center gap-2 [&>*]:flex-1",
+        className,
+      )}
+      {...props}
+    />
+  </ModalPrimitive.Close>
+);
+ModalFooter.displayName = "DialogFooter";
+
+const ModalTitle = React.forwardRef<
+  React.ElementRef<typeof ModalPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof ModalPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <ModalPrimitive.Title
+    ref={ref}
+    className={cn("lg-medium text-default-light", className)}
+    {...props}
+  />
+));
+ModalTitle.displayName = ModalPrimitive.Title.displayName;
+
+const ModalDescription = React.forwardRef<
+  React.ElementRef<typeof ModalPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof ModalPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <ModalPrimitive.Description
+    ref={ref}
+    className={cn("md-medium text-default-dark", className)}
+    {...props}
+  />
+));
+ModalDescription.displayName = ModalPrimitive.Description.displayName;
+
+export {
+  Modal,
+  ModalPortal,
+  ModalOverlay,
+  ModalTrigger,
+  ModalClose,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalTitle,
+  ModalDescription,
+};


### PR DESCRIPTION
## 작업 내용

- 새로운 공통 모달 컴포넌트를 구현 하였습니다 (`@/components/@common/modal/NewModal.tsx`)
- shadcn과 radix-ui/dialog 와 거의 똑같이 사용 가능합니다. 링크를 참고하시면 좋을 것 같습니다!
1. shadcn 링크 : https://ui.shadcn.com/docs/components/dialog
2. radix-ui 링크 : https://www.radix-ui.com/primitives/docs/components/dialog
- 추가로 shadcn과 radix-ui와는 다른 변경점이 있습니다.
1. ModalContent에 `type` prop이 추가되었습니다.
`"alert"`인 경우 외부를 클릭해도 닫히지 않으며 x 버튼이 없습니다.
기본값은 `"modal"`이며 외부를 클릭하면 닫힙니다.
2. ModalContent에 `hasCrossCloseIcon` prop이 추가되었습니다.
`true`인 경우 x 버튼이 표시됩니다. 기본값은 `false`입니다.
3. ModalFooter에 기본적으로 close 기능이 있습니다. (shadcn과는 다름)
- 사용예시
1. 일반 모달
![image](https://github.com/user-attachments/assets/9f73cad7-749b-4c9c-92c8-766970c0f77a)
```js
...
import {
  Modal,
  ModalContent,
  ModalDescription,
  ModalHeader,
  ModalTitle,
  ModalTrigger,
  ModalFooter,
} from "@/components/@common/modal/NewModal";
...
<Modal>
  <ModalTrigger>
    <Button>일반 모달 열기</Button>
  </ModalTrigger>
  <ModalContent hasCrossCloseIcon>
    <ModalHeader>
      <ModalTitle>일반 모달</ModalTitle>
      <ModalDescription>모달 형태</ModalDescription>
    </ModalHeader>
    <div>추가적인 content</div>
    <ModalFooter>
      <Button variant="outlinedSecondary">닫기</Button>
      <Button>진짜 닫기</Button>
  </ModalFooter>
  </ModalContent>
</Modal>
```
2. 경고 alert
![image](https://github.com/user-attachments/assets/a109b289-9c19-4a08-9de8-8cd9d2b8d84b)
```js
...
import {
  Modal,
  ModalContent,
  ModalDescription,
  ModalHeader,
  ModalTitle,
  ModalTrigger,
  ModalFooter,
} from "@/components/@common/modal/NewModal";
import Warning from "@/public/svg/warning.svg";
...
<Modal>
  <ModalTrigger>
    <Button>경고 모달 열기</Button>
  </ModalTrigger>
  <ModalContent type="alert">
    <ModalHeader>
      <Warning className="mx-auto mb-2" width={24} height={24} />
      <ModalTitle>경고!</ModalTitle>
      <ModalDescription>경고 Alert 형태</ModalDescription>
    </ModalHeader>
    <ModalFooter>
      <Button variant="danger">닫기</Button>
    </ModalFooter>
  </ModalContent>
</Modal>
```
3. form을 사용하려는 경우 (눌렀을때 닫혀야 하는 버튼에는 ModalClose를 이용)
```js
...
import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
import {
  Modal,
  ModalContent,
  ModalDescription,
  ModalHeader,
  ModalTitle,
  ModalTrigger,
  ModalFooter,
  ModalClose,
} from "@/components/@common/modal/NewModal";
...
<Modal>
  <ModalTrigger>
    <Button>입력 모달 열기</Button>
  </ModalTrigger>
  <ModalContent hasCrossCloseIcon>
    <ModalHeader>
      <ModalTitle>입력하기</ModalTitle>
      <VisuallyHidden asChild>
        <ModalDescription>입력하기 창입니다</ModalDescription>
      </VisuallyHidden>
    </ModalHeader>
    <form className="flex flex-col gap-6">
      <Input placeholder="입력하기" />
      <ModalClose asChild>
        <Button className="flex-1">제출 버튼</Button>
      </ModalClose>
    </form>
  </ModalContent>
</Modal>
```
4. 외부 버튼을 사용하는 경우 (기존 modal의 trigger로 boolean값을 직접 주는 case, ex. 드롭다운 버튼을 눌렀을때 열리는 모달)
```js
...
import {
  Modal,
  ModalContent,
  ModalDescription,
  ModalHeader,
  ModalTitle,
  ModalTrigger,
  ModalFooter,
} from "@/components/@common/modal/NewModal";
...
const [isModalOpen, toggleIsModalOpen] = useToggle(false);
...

<Button onClick={toggleIsModalOpen}>외부 모달 버튼</Button>
<Modal open={isModalOpen} onOpenChange={toggleIsModalOpen}>
  <ModalContent hasCrossCloseIcon>
    <ModalHeader>
      <ModalTitle>일반 모달</ModalTitle>
      <ModalDescription>모달 형태</ModalDescription>
    </ModalHeader>
    <ModalFooter>
      <Button variant="outlinedSecondary">닫기</Button>
      <Button>진짜 닫기</Button>
    </ModalFooter>
  </ModalContent>
</Modal>
```

## 리뷰 요구사항

- 궁금한 점이 있으시면 직접 물어보셔도 좋습니다!!
- 혹시 기존에 사용하시면서 예상되는 문제가 있다면 알려주세요~

## 기타

- Closes #146 
- #98 
